### PR TITLE
fix nil pointer dereference issue

### DIFF
--- a/query/rancher/rancherExtended.go
+++ b/query/rancher/rancherExtended.go
@@ -39,6 +39,8 @@ func (r Client) GetRancherCustomResourceCount() (map[string]int, error) {
 				version, _, err := unstructured.NestedSlice(rancherCustomResource.Object, "status", "storedVersions")
 				if err != nil {
 					log.Errorf("error retrieving version of Rancher CRD: %v", err)
+					m.Unlock() // Ensure the lock is released before returning
+                    return      // Exit the goroutine early
 				}
 
 				result, err := r.Client.Resource(schema.GroupVersionResource{
@@ -49,6 +51,8 @@ func (r Client) GetRancherCustomResourceCount() (map[string]int, error) {
 
 				if err != nil {
 					log.Errorf("error retrieving count of Rancher CRD: %v,%s,%s,%s\n", err, group, version[0].(string), resource)
+					m.Unlock() // Ensure the lock is released before returning
+                    return      // Exit the goroutine early
 				}
 				rancherCustomResources[rancherCustomResource.GetName()] = len(result.Items)
 				m.Unlock()


### PR DESCRIPTION
Fix issue:

`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x97bc23]

goroutine 332 [running]:
github.com/david-vtuk/prometheus-rancher-exporter/query/rancher.Client.GetRancherCustomResourceCount.func1({0xc001ebaf90})
	/home/runner/work/prometheus-rancher-exporter/prometheus-rancher-exporter/query/rancher/rancherExtended.go:53 +0x503
created by github.com/david-vtuk/prometheus-rancher-exporter/query/rancher.Client.GetRancherCustomResourceCount
	/home/runner/work/prometheus-rancher-exporter/prometheus-rancher-exporter/query/rancher/rancherExtended.go:34 +0x34b`